### PR TITLE
Add `user_mod` syntax and a few fixups

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ Easily display icon fonts in python markdown. Just add the CSS necessary for you
 
 This is a 3rd party extension for [Python Markdown](https://pythonhosted.org/Markdown/). You can see a [full list of 3rd party extensions here](https://github.com/waylan/Python-Markdown/wiki/Third-Party-Extensions).
 
-Although I made this to work with any icon font, I have added a `mod` syntax to add more prefixed classes to support [Font Awesome](http://fortawesome.github.io/Font-Awesome/) and its special classes such as `2x, 3x, muted, spin, etc`
+Although this works with any icon font, users can use a `mod` syntax to add more prefixed classes to support [Font Awesome](http://fortawesome.github.io/Font-Awesome/) and its special classes such as `2x, 3x, muted, spin, etc`
+
+Furthermore, users can add their own `user_mod` syntax to add additional, non-prefixed, pre-defined classes for greater control over their icons while allowing you to control exactly what styles are allowed.
 
 - You can create your own Icon Fonts using the IcoMoon app: http://icomoon.io/app/
 - A great pre-made Icon Font is [Font Awesome (GitHub Project)](http://fortawesome.github.io/Font-Awesome/)
@@ -33,6 +35,12 @@ Mod syntax:
 &icon-spinner:large,spin;
 ```
 
+User mod syntax:
+```
+&icon-html5::red;
+&icon-quote:2x:bold;
+```
+
 #### Example Markdown:
 
 ```
@@ -55,6 +63,7 @@ Just drop it in the extensions folder of the markdown package: `markdown/extensi
 # Usage / Setup:
 
 #### Default Prefix is "icon-":
+
 ##### In a Django Template: 
 `{{ textmd|markdown:"safe,iconfonts" }}`
 
@@ -66,6 +75,7 @@ converted_text = md.convert(text)
 
 
 #### Use a custom Prefix:
+
 ##### In a Django Template:
 `{{ textmd|markdown:"safe,iconfonts(prefix=mypref-)" }}`
 
@@ -84,7 +94,7 @@ md = markdown.Markdown(extensions=['iconfonts(prefix=)'])
 converted_text = md.convert(text)
 ```
 
-#### We also now support a `base` option which allows for Bootstrap 3 and FontAwesome 4
+#### The `base` option allows for use of Bootstrap 3 and FontAwesome 4 icons
 
 ##### In Python:
 ```
@@ -100,6 +110,28 @@ converted_text = md.convert(text)
 ```
 md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
 ```
+
+#### `prefix_base_pairs` option
+
+The `prefix_base_pairs` option allows for multiple prefix-base pairs to be specified, to allow you to support both Bootstrap 3/Glyphicon and FontAwesome icons
+
+##### In Python:
+```
+md = markdown.Markdown(extensions=['iconfonts'],
+                       extension_configs={
+                           'iconfonts': {
+                               'prefix_base_pairs': {
+                                   'fa-': 'fa',
+                                   'glyphicon-': 'glyphicon',
+                               }
+                           }
+                       })
+converted_text = md.convert(text)
+```
+
+**Input:** `&glyphicon-remove; &fa-html5;`
+
+**Output:** `<i aria-hidden="true" class="glyphicon glyphicon-remove"></i><i aria-hidden="true" class="fa fa-html5"></i>`
 
 # How to run the unit tests
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,6 @@ converted_text = md.convert(text)
 
 # How to run the unit tests
 
- - Install `Markdown` and `six`: `pip install markdown six`
+ - Install `Markdown`: `pip install markdown`
  - Install markdown icons. Copy the `iconfonts.py` file into `site-packages/markdown/extensions/`
  - Navigate to the test directory in CMD/terminal and run `python unit-tests.py -v`

--- a/README.md
+++ b/README.md
@@ -135,6 +135,6 @@ converted_text = md.convert(text)
 
 # How to run the unit tests
 
- - `pip install markdown`
+ - Install `Markdown` and `six`: `pip install markdown six`
  - Install markdown icons. Copy the `iconfonts.py` file into `site-packages/markdown/extensions/`
  - Navigate to the test directory in CMD/terminal and run `python unit-tests.py -v`

--- a/iconfonts.py
+++ b/iconfonts.py
@@ -107,7 +107,6 @@ Use it in any personal or commercial project you want.
 
 import markdown
 import re
-import six
 
 
 class IconFontsExtension(markdown.Extension):
@@ -169,7 +168,7 @@ class IconFontsExtension(markdown.Extension):
 		self.add_inline(md, 'iconfonts', IconFontsPattern, icon_regex, config)
 
 		# Register each of the pairings
-		for _prefix, _base in six.iteritems(config['prefix_base_pairs']):
+		for _prefix, _base in config['prefix_base_pairs'].items():
 
 			_prefix_base = _prefix if _prefix[-1] != '-' else _prefix[:-1]
 

--- a/iconfonts.py
+++ b/iconfonts.py
@@ -7,6 +7,13 @@ Version: 2.1
 Description:
     Use this extension to display icon font icons in python markdown. Just add the css necessary for your font and add this extension.
 
+Features:
+    - Support FontAwesome or Bootstrap 3/Glyphicons or both at the same time!
+    - Allow users to specify additional modifiers, like 'fa-2x' from FontAwesome
+    - Force users to use pre-defined classes to style their icons instead of
+      allowing them to specify styles themselves
+    - Allow users to specify additional classes, like 'red'
+
 Syntax:
     - Accepts a-z, A-Z, 0-9, _ (underscore), and - (hypen)
     - Uses HTML Entity like syntax
@@ -23,9 +30,12 @@ Syntax:
 Example Markdown:
     I love &icon-html5; and &icon-css3;
     &icon-spinner:large,spin; Sorry we have to load...
+    &icon-spinner:large,spin:red; Sorry we have to load...
+
 Output:
     I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>
     <i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...
+    <i aria-hidden="true" class="icon-spinner icon-large icon-spin red"></i> Sorry we have to load...
 
 
 Installation:
@@ -38,8 +48,10 @@ Usage/Setup:
             {{ textmd|markdown:"safe,iconfonts" }}
 
         In Python:
-            md = markdown.Markdown(extensions=['iconfonts'])
-            converted_text = md.convert(text)
+            >>> text = '&icon-html5;'
+            >>> md = markdown.Markdown(extensions=['iconfonts'])
+            >>> converted_text = md.convert(text)
+            '<i aria-hidden="true" class="icon-html5"></i>'
 
 
     Use a custom Prefix:
@@ -47,8 +59,10 @@ Usage/Setup:
             {{ textmd|markdown:"safe,iconfonts(prefix=mypref-)" }}
 
         In Python:
-            md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
-            converted_text = md.convert(text)
+            >>> text = '&mypref-html5;'
+            >>> md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
+            >>> converted_text = md.convert(text)
+            '<i aria-hidden="true" class="mypref-html5"></i>'
 
 
     Use no prefix (just in case you couldn't figure it out :P):
@@ -56,28 +70,44 @@ Usage/Setup:
             {{ textmd|markdown:"safe,iconfonts(prefix=)" }}
 
         In Python:
-            md = markdown.Markdown(extensions=['iconfonts(prefix=)'])
-            converted_text = md.convert(text)
+            >>> text = '&html5;'
+            >>> md = markdown.Markdown(extensions=['iconfonts(prefix=)'])
+            >>> converted_text = md.convert(text)
+            '<i aria-hidden="true" class="html5"></i>'
 
-    We also now support a base option which allows for Bootstrap 3 and FontAwesome 4
+    Use the base option which allows for Bootstrap 3 and FontAwesome 4:
         In Python:
-            md = markdown.Markdown(extensions=['iconfonts(base=icon)'])
-            converted_text = md.convert(text)
+            >>> text = '&fa-html5;'
+            >>> md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
+            >>> converted_text = md.convert(text)
+            '<i aria-hidden="true" class="fa icon-html5"></i>'
 
-        Input: `&icon-html5;`
-        Output: `<i aria-hidden="true" class="icon icon-html5"></i>`
+            >>> text = '&glyphicon-remove;'
+            >>> md = markdown.Markdown(extensions=['iconfonts(prefix=glyphicon-, base=glyphicon)'])
+            >>> converted_text = md.convert(text)
+            '<i aria-hidden="true" class="glyphicon glyphicon-remove"></i>'
 
-    Combine options with a comma:
-        md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
+    Or support both Bootstrap 3/Glyphicons and FontAwesome 4 at the same time:
+        In Python:
+            >>> text = '&fa-html5; &glyphicon-remove;''
+            >>> md = markdown.Markdown(extensions=['iconfonts'],
+            >>>                        extension_configs={
+            >>>                            'fa': 'fa',
+            >>>                            'glyphicon': 'glyphicon',
+            >>>                        })
+            >>> converted_text = md.convert(text)
+            '<i aria-hidden="true" class="fa fa-html5"></i>'
+            '<i aria-hidden="true" class="glyphicon glyphicon-remove"></i>'
 
 
 Copyright 2014 [Eric Eastwood](http://ericeastwood.com/)
 
 Use it in any personal or commercial project you want.
-
 """
 
 import markdown
+import re
+import six
 
 
 class IconFontsExtension(markdown.Extension):
@@ -88,7 +118,8 @@ class IconFontsExtension(markdown.Extension):
         # define default configs
         self.config = {
             'prefix': ['icon-', "Custom class prefix."],
-            'base': ['', "Base class added to each icon"]
+            'base': ['', "Base class added to each icon"],
+            'prefix_base_pairs': [{}, "Prefix/base pairs"],
         }
 
         # Override defaults with user settings
@@ -113,27 +144,41 @@ class IconFontsExtension(markdown.Extension):
         # We can use this instead of the legacy for loop to set the config above
         #super(IconFontsExtension, self).__init__(*args, **kwargs)
 
+    def add_inline(self, md, name, klass, re, config):
+        pattern = klass(re, md, config)
+        md.inlinePatterns.add(name, pattern, "<reference")
+
     def extendMarkdown(self, md, md_globals):
         config = self.getConfigs()
         #print("config" + str(config))
-
-        md.registerExtension(self)
 
         # Change prefix to what they had the in the config
         # Capture "&icon-namehere;" or "&icon-namehere:2x;" or "&icon-namehere:2x,muted;"
         # https://www.debuggex.com/r/weK9ehGY0HG6uKrg
         prefix = config['prefix']
         icon_regex_start = r'&'
-        icon_regex_end = r'(?P<name>[a-zA-Z0-9-]+)(:(?P<mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)){0,1};'
+        icon_regex_end = r'(?P<name>[a-zA-Z0-9-]+)(:(?P<mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)?(:(?P<user_mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)?)?)?;'
+        #                  ^---------------------^^ ^                    ^--------------^ ^ ^ ^                         ^--------------^ ^ ^ ^
+        #                                         | +-------------------------------------+ | +------------------------------------------+ | |
+        #                                         |                                         +----------------------------------------------+ |
+        #                                         +------------------------------------------------------------------------------------------+
         # This is the full regex we use. Only reason we have pieces above is to easily change the prefix to something custom
-        icon_regex = icon_regex_start + prefix + icon_regex_end
+        icon_regex = ''.join([icon_regex_start, prefix, icon_regex_end])
 
-        md.inlinePatterns['iconfonts'] = IconFontsPattern(icon_regex, md, config)
+        # Register the global one
+        self.add_inline(md, 'iconfonts', IconFontsPattern, icon_regex, config)
 
+        # Register each of the pairings
+        for _prefix, _base in six.iteritems(config['prefix_base_pairs']):
 
-# http://pythonhosted.org/Markdown/extensions/api.html#makeextension
-def makeExtension(*args, **kwargs):
-    return IconFontsExtension(*args, **kwargs)
+            _prefix_base = _prefix if _prefix[-1] != '-' else _prefix[:-1]
+
+            icon_regex = ''.join([icon_regex_start, _prefix, icon_regex_end])
+
+            self.add_inline(
+                md, 'iconfonts_{}'.format(_prefix_base),
+                IconFontsPattern, icon_regex,
+                {'prefix': _prefix, 'base': _base})
 
 
 class IconFontsPattern(markdown.inlinepatterns.Pattern):
@@ -152,20 +197,44 @@ class IconFontsPattern(markdown.inlinepatterns.Pattern):
         # Create the <i> element
         el = markdown.util.etree.Element("i")
 
-        # Mods are modifier classes. The syntax in the markdown is "&icon-namehere:2x;" and with multiple "&icon-spinner:2x,spin;"
+        base = self.config['base']
+        prefix = self.config['prefix']
+
+        icon_class_name = match_dict.get("name")
+
+        # Mods are modifier classes. The syntax in the markdown is:
+        # "&icon-namehere:2x;" and with multiple "&icon-spinner:2x,spin;"
         mod_classes_string = ""
-        if(match_dict.get("mod")):
-            # Make a string with each modifier like: " icon-2x iconspin"
-            mod_classes_string = " " + ' '.join((self.config['prefix'] + c) for c in match_dict.get("mod").split(",") if c)
+        if match_dict.get("mod"):
+            # Make a string with each modifier like: "fa-2x fa-spin"
+            mod_classes_string = ' '.join('{}{}'.format(prefix, c) for c in match_dict.get("mod").split(",") if c)
 
-        base_class = ""
-        if(self.config['base']):
-            base_class = self.config['base'] + " "
+        # User mods are modifier classes that shouldn't be prefixed with
+        # prefix. The syntax in the markdown is:
+        # "&icon-namehere::red;" and with multiple "&icon-spinner::red,bold;"
+        user_mod_classes_string = ""
+        if match_dict.get("user_mod"):
+            # Make a string with each modifier like "red bold"
+            user_mod_classes_string = ' '.join(uc for uc in match_dict.get("user_mod").split(",") if uc)
 
-        icon_class = self.config['prefix'] + match_dict.get("name")
+        if prefix != '':
+            icon_class = '{}{}'.format(prefix, icon_class_name)
+        else:
+            icon_class = icon_class_name
 
         # Add the icon classes to the <i> element
-        el.set('class', base_class + icon_class + mod_classes_string)
+        classes = '{} {} {} {}'.format(base, icon_class, mod_classes_string, user_mod_classes_string)
+
+        # Clean up classes
+        classes = classes.strip()
+        classes = re.sub(r'\s{2,}', ' ', classes)
+
+        el.set('class', classes)
         # This is for accessibility and text-to-speech browsers so they don't try to read it
         el.set('aria-hidden', 'true')
         return el
+
+
+# http://pythonhosted.org/Markdown/extensions/api.html#makeextension
+def makeExtension(*args, **kwargs):
+    return IconFontsExtension(*args, **kwargs)

--- a/iconfonts.py
+++ b/iconfonts.py
@@ -26,7 +26,7 @@ Example Markdown:
 Output:
     I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>
     <i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...
-    
+
 
 Installation:
     Just drop it in the extensions folder of the markdown package. (markdown/extensions).
@@ -34,7 +34,7 @@ Installation:
 
 Usage/Setup:
     Default Prefix is "icon-":
-        In a Django Template: 
+        In a Django Template:
             {{ textmd|markdown:"safe,iconfonts" }}
 
         In Python:
@@ -69,7 +69,7 @@ Usage/Setup:
 
     Combine options with a comma:
         md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
-        
+
 
 Copyright 2014 [Eric Eastwood](http://ericeastwood.com/)
 
@@ -78,6 +78,7 @@ Use it in any personal or commercial project you want.
 """
 
 import markdown
+
 
 class IconFontsExtension(markdown.Extension):
     """ IconFonts Extension for Python-Markdown. """
@@ -95,9 +96,12 @@ class IconFontsExtension(markdown.Extension):
         if len(args):
             for key, value in args[0]:
                 # convert strings to booleans
-                if value == 'True': value = True
-                if value == 'False': value = False
-                if value == 'None': value = None
+                if value == 'True':
+                    value = True
+                if value == 'False':
+                    value = False
+                if value == 'None':
+                    value = None
 
                 self.setConfig(key, value)
 
@@ -106,13 +110,11 @@ class IconFontsExtension(markdown.Extension):
         if hasattr(self, 'setConfigs'):
             self.setConfigs(kwargs)
 
-        
         # We can use this instead of the legacy for loop to set the config above
         #super(IconFontsExtension, self).__init__(*args, **kwargs)
 
-
     def extendMarkdown(self, md, md_globals):
-        config = self.getConfigs();
+        config = self.getConfigs()
         #print("config" + str(config))
 
         md.registerExtension(self)
@@ -134,9 +136,7 @@ def makeExtension(*args, **kwargs):
     return IconFontsExtension(*args, **kwargs)
 
 
-
 class IconFontsPattern(markdown.inlinepatterns.Pattern):
-    
     def __init__(self, pattern, md, config):
         # Pass the patterna and markdown instance
         super(IconFontsPattern, self).__init__(pattern, md)
@@ -148,7 +148,7 @@ class IconFontsPattern(markdown.inlinepatterns.Pattern):
 
         # The dictionary keys come from named capture groups in the regex
         match_dict = match.groupdict()
-        
+
         # Create the <i> element
         el = markdown.util.etree.Element("i")
 

--- a/iconfonts.py
+++ b/iconfonts.py
@@ -5,71 +5,71 @@ IconFonts Extension for Python-Markdown
 Version: 2.1
 
 Description:
-	Use this extension to display icon font icons in python markdown. Just add the css necessary for your font and add this extension.
+    Use this extension to display icon font icons in python markdown. Just add the css necessary for your font and add this extension.
 
 Syntax:
-	- Accepts a-z, A-Z, 0-9, _ (underscore), and - (hypen)
-	- Uses HTML Entity like syntax
+    - Accepts a-z, A-Z, 0-9, _ (underscore), and - (hypen)
+    - Uses HTML Entity like syntax
 
-	&icon-html5;
-	&icon-css3;
-	&icon-my-icon;
+    &icon-html5;
+    &icon-css3;
+    &icon-my-icon;
 
-	&icon-html5:2x;
-	&icon-quote:3x,muted;
-	&icon-spinner:large,spin;
+    &icon-html5:2x;
+    &icon-quote:3x,muted;
+    &icon-spinner:large,spin;
 
 
 Example Markdown:
-	I love &icon-html5; and &icon-css3;
-	&icon-spinner:large,spin; Sorry we have to load...
+    I love &icon-html5; and &icon-css3;
+    &icon-spinner:large,spin; Sorry we have to load...
 Output:
-	I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>
-	<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...
-	
+    I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>
+    <i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...
+    
 
 Installation:
-	Just drop it in the extensions folder of the markdown package. (markdown/extensions).
-	Also check out: https://pythonhosted.org/Markdown/extensions/index.html
+    Just drop it in the extensions folder of the markdown package. (markdown/extensions).
+    Also check out: https://pythonhosted.org/Markdown/extensions/index.html
 
 Usage/Setup:
-	Default Prefix is "icon-":
-		In a Django Template: 
-			{{ textmd|markdown:"safe,iconfonts" }}
+    Default Prefix is "icon-":
+        In a Django Template: 
+            {{ textmd|markdown:"safe,iconfonts" }}
 
-		In Python:
-			md = markdown.Markdown(extensions=['iconfonts'])
-			converted_text = md.convert(text)
-
-
-	Use a custom Prefix:
-		In a Django Template:
-			{{ textmd|markdown:"safe,iconfonts(prefix=mypref-)" }}
-
-		In Python:
-			md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
-			converted_text = md.convert(text)
+        In Python:
+            md = markdown.Markdown(extensions=['iconfonts'])
+            converted_text = md.convert(text)
 
 
-	Use no prefix (just in case you couldn't figure it out :P):
-		In a Django Template:
-			{{ textmd|markdown:"safe,iconfonts(prefix=)" }}
+    Use a custom Prefix:
+        In a Django Template:
+            {{ textmd|markdown:"safe,iconfonts(prefix=mypref-)" }}
 
-		In Python:
-			md = markdown.Markdown(extensions=['iconfonts(prefix=)'])
-			converted_text = md.convert(text)
+        In Python:
+            md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
+            converted_text = md.convert(text)
 
-	We also now support a base option which allows for Bootstrap 3 and FontAwesome 4
-		In Python:
-			md = markdown.Markdown(extensions=['iconfonts(base=icon)'])
-			converted_text = md.convert(text)
 
-		Input: `&icon-html5;`
-		Output: `<i aria-hidden="true" class="icon icon-html5"></i>`
+    Use no prefix (just in case you couldn't figure it out :P):
+        In a Django Template:
+            {{ textmd|markdown:"safe,iconfonts(prefix=)" }}
 
-	Combine options with a comma:
-		md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
-		
+        In Python:
+            md = markdown.Markdown(extensions=['iconfonts(prefix=)'])
+            converted_text = md.convert(text)
+
+    We also now support a base option which allows for Bootstrap 3 and FontAwesome 4
+        In Python:
+            md = markdown.Markdown(extensions=['iconfonts(base=icon)'])
+            converted_text = md.convert(text)
+
+        Input: `&icon-html5;`
+        Output: `<i aria-hidden="true" class="icon icon-html5"></i>`
+
+    Combine options with a comma:
+        md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
+        
 
 Copyright 2014 [Eric Eastwood](http://ericeastwood.com/)
 
@@ -80,92 +80,92 @@ Use it in any personal or commercial project you want.
 import markdown
 
 class IconFontsExtension(markdown.Extension):
-	""" IconFonts Extension for Python-Markdown. """
+    """ IconFonts Extension for Python-Markdown. """
 
-	def __init__(self, *args, **kwargs):
+    def __init__(self, *args, **kwargs):
 
-		# define default configs
-		self.config = {
-			'prefix': ['icon-', "Custom class prefix."],
-			'base': ['', "Base class added to each icon"]
-		}
+        # define default configs
+        self.config = {
+            'prefix': ['icon-', "Custom class prefix."],
+            'base': ['', "Base class added to each icon"]
+        }
 
-		# Override defaults with user settings
-		# This is legacy code for versions older than 2.5.1.
-		if len(args):
-			for key, value in args[0]:
-				# convert strings to booleans
-				if value == 'True': value = True
-				if value == 'False': value = False
-				if value == 'None': value = None
+        # Override defaults with user settings
+        # This is legacy code for versions older than 2.5.1.
+        if len(args):
+            for key, value in args[0]:
+                # convert strings to booleans
+                if value == 'True': value = True
+                if value == 'False': value = False
+                if value == 'None': value = None
 
-				self.setConfig(key, value)
+                self.setConfig(key, value)
 
-		# Override defaults with user settings
-		# This is not legacy code but is used instead of the super call below because we have to support the legacy version
-		if hasattr(self, 'setConfigs'):
-			self.setConfigs(kwargs)
+        # Override defaults with user settings
+        # This is not legacy code but is used instead of the super call below because we have to support the legacy version
+        if hasattr(self, 'setConfigs'):
+            self.setConfigs(kwargs)
 
-		
-		# We can use this instead of the legacy for loop to set the config above
-		#super(IconFontsExtension, self).__init__(*args, **kwargs)
+        
+        # We can use this instead of the legacy for loop to set the config above
+        #super(IconFontsExtension, self).__init__(*args, **kwargs)
 
 
-	def extendMarkdown(self, md, md_globals):
-		config = self.getConfigs();
-		#print("config" + str(config))
+    def extendMarkdown(self, md, md_globals):
+        config = self.getConfigs();
+        #print("config" + str(config))
 
-		md.registerExtension(self)
+        md.registerExtension(self)
 
-		# Change prefix to what they had the in the config
-		# Capture "&icon-namehere;" or "&icon-namehere:2x;" or "&icon-namehere:2x,muted;"
-		# https://www.debuggex.com/r/weK9ehGY0HG6uKrg
-		prefix = config['prefix']
-		icon_regex_start = r'&'
-		icon_regex_end = r'(?P<name>[a-zA-Z0-9-]+)(:(?P<mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)){0,1};'
-		# This is the full regex we use. Only reason we have pieces above is to easily change the prefix to something custom
-		icon_regex = icon_regex_start + prefix + icon_regex_end
+        # Change prefix to what they had the in the config
+        # Capture "&icon-namehere;" or "&icon-namehere:2x;" or "&icon-namehere:2x,muted;"
+        # https://www.debuggex.com/r/weK9ehGY0HG6uKrg
+        prefix = config['prefix']
+        icon_regex_start = r'&'
+        icon_regex_end = r'(?P<name>[a-zA-Z0-9-]+)(:(?P<mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)){0,1};'
+        # This is the full regex we use. Only reason we have pieces above is to easily change the prefix to something custom
+        icon_regex = icon_regex_start + prefix + icon_regex_end
 
-		md.inlinePatterns['iconfonts'] = IconFontsPattern(icon_regex, md, config)
+        md.inlinePatterns['iconfonts'] = IconFontsPattern(icon_regex, md, config)
 
 
 # http://pythonhosted.org/Markdown/extensions/api.html#makeextension
 def makeExtension(*args, **kwargs):
-	return IconFontsExtension(*args, **kwargs)
+    return IconFontsExtension(*args, **kwargs)
 
 
 
 class IconFontsPattern(markdown.inlinepatterns.Pattern):
-	
-	def __init__(self, pattern, md, config):
-		# Pass the patterna and markdown instance
-		super(IconFontsPattern, self).__init__(pattern, md)
+    
+    def __init__(self, pattern, md, config):
+        # Pass the patterna and markdown instance
+        super(IconFontsPattern, self).__init__(pattern, md)
 
-		self.config = config
+        self.config = config
 
-	""" Return a <i> element with the necessary classes"""
-	def handleMatch(self, match):
+    """ Return a <i> element with the necessary classes"""
+    def handleMatch(self, match):
 
-		# The dictionary keys come from named capture groups in the regex
-		match_dict = match.groupdict()
-		
-		# Create the <i> element
-		el = markdown.util.etree.Element("i")
+        # The dictionary keys come from named capture groups in the regex
+        match_dict = match.groupdict()
+        
+        # Create the <i> element
+        el = markdown.util.etree.Element("i")
 
-		# Mods are modifier classes. The syntax in the markdown is "&icon-namehere:2x;" and with multiple "&icon-spinner:2x,spin;"
-		mod_classes_string = ""
-		if(match_dict.get("mod")):
-			# Make a string with each modifier like: " icon-2x iconspin"
-			mod_classes_string = " " + ' '.join((self.config['prefix'] + c) for c in match_dict.get("mod").split(",") if c)
+        # Mods are modifier classes. The syntax in the markdown is "&icon-namehere:2x;" and with multiple "&icon-spinner:2x,spin;"
+        mod_classes_string = ""
+        if(match_dict.get("mod")):
+            # Make a string with each modifier like: " icon-2x iconspin"
+            mod_classes_string = " " + ' '.join((self.config['prefix'] + c) for c in match_dict.get("mod").split(",") if c)
 
-		base_class = ""
-		if(self.config['base']):
-			base_class = self.config['base'] + " "
+        base_class = ""
+        if(self.config['base']):
+            base_class = self.config['base'] + " "
 
-		icon_class = self.config['prefix'] + match_dict.get("name")
+        icon_class = self.config['prefix'] + match_dict.get("name")
 
-		# Add the icon classes to the <i> element
-		el.set('class', base_class + icon_class + mod_classes_string)
-		# This is for accessibility and text-to-speech browsers so they don't try to read it
-		el.set('aria-hidden', 'true')
-		return el
+        # Add the icon classes to the <i> element
+        el.set('class', base_class + icon_class + mod_classes_string)
+        # This is for accessibility and text-to-speech browsers so they don't try to read it
+        el.set('aria-hidden', 'true')
+        return el

--- a/iconfonts.py
+++ b/iconfonts.py
@@ -5,99 +5,99 @@ IconFonts Extension for Python-Markdown
 Version: 2.1
 
 Description:
-    Use this extension to display icon font icons in python markdown. Just add the css necessary for your font and add this extension.
+	Use this extension to display icon font icons in python markdown. Just add the css necessary for your font and add this extension.
 
 Features:
-    - Support FontAwesome or Bootstrap 3/Glyphicons or both at the same time!
-    - Allow users to specify additional modifiers, like 'fa-2x' from FontAwesome
-    - Force users to use pre-defined classes to style their icons instead of
-      allowing them to specify styles themselves
-    - Allow users to specify additional classes, like 'red'
+	- Support FontAwesome or Bootstrap 3/Glyphicons or both at the same time!
+	- Allow users to specify additional modifiers, like 'fa-2x' from FontAwesome
+	- Force users to use pre-defined classes to style their icons instead of
+		allowing them to specify styles themselves
+	- Allow users to specify additional classes, like 'red'
 
 Syntax:
-    - Accepts a-z, A-Z, 0-9, _ (underscore), and - (hypen)
-    - Uses HTML Entity like syntax
+	- Accepts a-z, A-Z, 0-9, _ (underscore), and - (hypen)
+	- Uses HTML Entity like syntax
 
-    &icon-html5;
-    &icon-css3;
-    &icon-my-icon;
+	&icon-html5;
+	&icon-css3;
+	&icon-my-icon;
 
-    &icon-html5:2x;
-    &icon-quote:3x,muted;
-    &icon-spinner:large,spin;
+	&icon-html5:2x;
+	&icon-quote:3x,muted;
+	&icon-spinner:large,spin;
 
 
 Example Markdown:
-    I love &icon-html5; and &icon-css3;
-    &icon-spinner:large,spin; Sorry we have to load...
-    &icon-spinner:large,spin:red; Sorry we have to load...
+	I love &icon-html5; and &icon-css3;
+	&icon-spinner:large,spin; Sorry we have to load...
+	&icon-spinner:large,spin:red; Sorry we have to load...
 
 Output:
-    I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>
-    <i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...
-    <i aria-hidden="true" class="icon-spinner icon-large icon-spin red"></i> Sorry we have to load...
+	I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>
+	<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...
+	<i aria-hidden="true" class="icon-spinner icon-large icon-spin red"></i> Sorry we have to load...
 
 
 Installation:
-    Just drop it in the extensions folder of the markdown package. (markdown/extensions).
-    Also check out: https://pythonhosted.org/Markdown/extensions/index.html
+	Just drop it in the extensions folder of the markdown package. (markdown/extensions).
+	Also check out: https://pythonhosted.org/Markdown/extensions/index.html
 
 Usage/Setup:
-    Default Prefix is "icon-":
-        In a Django Template:
-            {{ textmd|markdown:"safe,iconfonts" }}
+	Default Prefix is "icon-":
+		In a Django Template:
+			{{ textmd|markdown:"safe,iconfonts" }}
 
-        In Python:
-            >>> text = '&icon-html5;'
-            >>> md = markdown.Markdown(extensions=['iconfonts'])
-            >>> converted_text = md.convert(text)
-            '<i aria-hidden="true" class="icon-html5"></i>'
-
-
-    Use a custom Prefix:
-        In a Django Template:
-            {{ textmd|markdown:"safe,iconfonts(prefix=mypref-)" }}
-
-        In Python:
-            >>> text = '&mypref-html5;'
-            >>> md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
-            >>> converted_text = md.convert(text)
-            '<i aria-hidden="true" class="mypref-html5"></i>'
+		In Python:
+			>>> text = '&icon-html5;'
+			>>> md = markdown.Markdown(extensions=['iconfonts'])
+			>>> converted_text = md.convert(text)
+			'<i aria-hidden="true" class="icon-html5"></i>'
 
 
-    Use no prefix (just in case you couldn't figure it out :P):
-        In a Django Template:
-            {{ textmd|markdown:"safe,iconfonts(prefix=)" }}
+	Use a custom Prefix:
+		In a Django Template:
+			{{ textmd|markdown:"safe,iconfonts(prefix=mypref-)" }}
 
-        In Python:
-            >>> text = '&html5;'
-            >>> md = markdown.Markdown(extensions=['iconfonts(prefix=)'])
-            >>> converted_text = md.convert(text)
-            '<i aria-hidden="true" class="html5"></i>'
+		In Python:
+			>>> text = '&mypref-html5;'
+			>>> md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
+			>>> converted_text = md.convert(text)
+			'<i aria-hidden="true" class="mypref-html5"></i>'
 
-    Use the base option which allows for Bootstrap 3 and FontAwesome 4:
-        In Python:
-            >>> text = '&fa-html5;'
-            >>> md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
-            >>> converted_text = md.convert(text)
-            '<i aria-hidden="true" class="fa icon-html5"></i>'
 
-            >>> text = '&glyphicon-remove;'
-            >>> md = markdown.Markdown(extensions=['iconfonts(prefix=glyphicon-, base=glyphicon)'])
-            >>> converted_text = md.convert(text)
-            '<i aria-hidden="true" class="glyphicon glyphicon-remove"></i>'
+	Use no prefix (just in case you couldn't figure it out :P):
+		In a Django Template:
+			{{ textmd|markdown:"safe,iconfonts(prefix=)" }}
 
-    Or support both Bootstrap 3/Glyphicons and FontAwesome 4 at the same time:
-        In Python:
-            >>> text = '&fa-html5; &glyphicon-remove;''
-            >>> md = markdown.Markdown(extensions=['iconfonts'],
-            >>>                        extension_configs={
-            >>>                            'fa': 'fa',
-            >>>                            'glyphicon': 'glyphicon',
-            >>>                        })
-            >>> converted_text = md.convert(text)
-            '<i aria-hidden="true" class="fa fa-html5"></i>'
-            '<i aria-hidden="true" class="glyphicon glyphicon-remove"></i>'
+		In Python:
+			>>> text = '&html5;'
+			>>> md = markdown.Markdown(extensions=['iconfonts(prefix=)'])
+			>>> converted_text = md.convert(text)
+			'<i aria-hidden="true" class="html5"></i>'
+
+	Use the base option which allows for Bootstrap 3 and FontAwesome 4:
+		In Python:
+			>>> text = '&fa-html5;'
+			>>> md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
+			>>> converted_text = md.convert(text)
+			'<i aria-hidden="true" class="fa icon-html5"></i>'
+
+			>>> text = '&glyphicon-remove;'
+			>>> md = markdown.Markdown(extensions=['iconfonts(prefix=glyphicon-, base=glyphicon)'])
+			>>> converted_text = md.convert(text)
+			'<i aria-hidden="true" class="glyphicon glyphicon-remove"></i>'
+
+	Or support both Bootstrap 3/Glyphicons and FontAwesome 4 at the same time:
+		In Python:
+			>>> text = '&fa-html5; &glyphicon-remove;''
+			>>> md = markdown.Markdown(extensions=['iconfonts'],
+			>>>                        extension_configs={
+			>>>                            'fa': 'fa',
+			>>>                            'glyphicon': 'glyphicon',
+			>>>                        })
+			>>> converted_text = md.convert(text)
+			'<i aria-hidden="true" class="fa fa-html5"></i>'
+			'<i aria-hidden="true" class="glyphicon glyphicon-remove"></i>'
 
 
 Copyright 2014 [Eric Eastwood](http://ericeastwood.com/)
@@ -111,130 +111,130 @@ import six
 
 
 class IconFontsExtension(markdown.Extension):
-    """ IconFonts Extension for Python-Markdown. """
+	""" IconFonts Extension for Python-Markdown. """
 
-    def __init__(self, *args, **kwargs):
+	def __init__(self, *args, **kwargs):
 
-        # define default configs
-        self.config = {
-            'prefix': ['icon-', "Custom class prefix."],
-            'base': ['', "Base class added to each icon"],
-            'prefix_base_pairs': [{}, "Prefix/base pairs"],
-        }
+		# define default configs
+		self.config = {
+			'prefix': ['icon-', "Custom class prefix."],
+			'base': ['', "Base class added to each icon"],
+			'prefix_base_pairs': [{}, "Prefix/base pairs"],
+		}
 
-        # Override defaults with user settings
-        # This is legacy code for versions older than 2.5.1.
-        if len(args):
-            for key, value in args[0]:
-                # convert strings to booleans
-                if value == 'True':
-                    value = True
-                if value == 'False':
-                    value = False
-                if value == 'None':
-                    value = None
+		# Override defaults with user settings
+		# This is legacy code for versions older than 2.5.1.
+		if len(args):
+			for key, value in args[0]:
+				# convert strings to booleans
+				if value == 'True':
+					value = True
+				if value == 'False':
+					value = False
+				if value == 'None':
+					value = None
 
-                self.setConfig(key, value)
+				self.setConfig(key, value)
 
-        # Override defaults with user settings
-        # This is not legacy code but is used instead of the super call below because we have to support the legacy version
-        if hasattr(self, 'setConfigs'):
-            self.setConfigs(kwargs)
+		# Override defaults with user settings
+		# This is not legacy code but is used instead of the super call below because we have to support the legacy version
+		if hasattr(self, 'setConfigs'):
+			self.setConfigs(kwargs)
 
-        # We can use this instead of the legacy for loop to set the config above
-        #super(IconFontsExtension, self).__init__(*args, **kwargs)
+		# We can use this instead of the legacy for loop to set the config above
+		#super(IconFontsExtension, self).__init__(*args, **kwargs)
 
-    def add_inline(self, md, name, klass, re, config):
-        pattern = klass(re, md, config)
-        md.inlinePatterns.add(name, pattern, "<reference")
+	def add_inline(self, md, name, klass, re, config):
+		pattern = klass(re, md, config)
+		md.inlinePatterns.add(name, pattern, "<reference")
 
-    def extendMarkdown(self, md, md_globals):
-        config = self.getConfigs()
-        #print("config" + str(config))
+	def extendMarkdown(self, md, md_globals):
+		config = self.getConfigs()
+		#print("config" + str(config))
 
-        # Change prefix to what they had the in the config
-        # Capture "&icon-namehere;" or "&icon-namehere:2x;" or "&icon-namehere:2x,muted;"
-        # https://www.debuggex.com/r/weK9ehGY0HG6uKrg
-        prefix = config['prefix']
-        icon_regex_start = r'&'
-        icon_regex_end = r'(?P<name>[a-zA-Z0-9-]+)(:(?P<mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)?(:(?P<user_mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)?)?)?;'
-        #                  ^---------------------^^ ^                    ^--------------^ ^ ^ ^                         ^--------------^ ^ ^ ^
-        #                                         | +-------------------------------------+ | +------------------------------------------+ | |
-        #                                         |                                         +----------------------------------------------+ |
-        #                                         +------------------------------------------------------------------------------------------+
-        # This is the full regex we use. Only reason we have pieces above is to easily change the prefix to something custom
-        icon_regex = ''.join([icon_regex_start, prefix, icon_regex_end])
+		# Change prefix to what they had the in the config
+		# Capture "&icon-namehere;" or "&icon-namehere:2x;" or "&icon-namehere:2x,muted;"
+		# https://www.debuggex.com/r/weK9ehGY0HG6uKrg
+		prefix = config['prefix']
+		icon_regex_start = r'&'
+		icon_regex_end = r'(?P<name>[a-zA-Z0-9-]+)(:(?P<mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)?(:(?P<user_mod>[a-zA-Z0-9-]+(,[a-zA-Z0-9-]+)*)?)?)?;'
+		#                  ^---------------------^^ ^                    ^--------------^ ^ ^ ^                         ^--------------^ ^ ^ ^
+		#                                         | +-------------------------------------+ | +------------------------------------------+ | |
+		#                                         |                                         +----------------------------------------------+ |
+		#                                         +------------------------------------------------------------------------------------------+
+		# This is the full regex we use. Only reason we have pieces above is to easily change the prefix to something custom
+		icon_regex = ''.join([icon_regex_start, prefix, icon_regex_end])
 
-        # Register the global one
-        self.add_inline(md, 'iconfonts', IconFontsPattern, icon_regex, config)
+		# Register the global one
+		self.add_inline(md, 'iconfonts', IconFontsPattern, icon_regex, config)
 
-        # Register each of the pairings
-        for _prefix, _base in six.iteritems(config['prefix_base_pairs']):
+		# Register each of the pairings
+		for _prefix, _base in six.iteritems(config['prefix_base_pairs']):
 
-            _prefix_base = _prefix if _prefix[-1] != '-' else _prefix[:-1]
+			_prefix_base = _prefix if _prefix[-1] != '-' else _prefix[:-1]
 
-            icon_regex = ''.join([icon_regex_start, _prefix, icon_regex_end])
+			icon_regex = ''.join([icon_regex_start, _prefix, icon_regex_end])
 
-            self.add_inline(
-                md, 'iconfonts_{}'.format(_prefix_base),
-                IconFontsPattern, icon_regex,
-                {'prefix': _prefix, 'base': _base})
+			self.add_inline(
+				md, 'iconfonts_{}'.format(_prefix_base),
+				IconFontsPattern, icon_regex,
+				{'prefix': _prefix, 'base': _base})
 
 
 class IconFontsPattern(markdown.inlinepatterns.Pattern):
-    def __init__(self, pattern, md, config):
-        # Pass the patterna and markdown instance
-        super(IconFontsPattern, self).__init__(pattern, md)
+	def __init__(self, pattern, md, config):
+		# Pass the patterna and markdown instance
+		super(IconFontsPattern, self).__init__(pattern, md)
 
-        self.config = config
+		self.config = config
 
-    """ Return a <i> element with the necessary classes"""
-    def handleMatch(self, match):
+	""" Return a <i> element with the necessary classes"""
+	def handleMatch(self, match):
 
-        # The dictionary keys come from named capture groups in the regex
-        match_dict = match.groupdict()
+		# The dictionary keys come from named capture groups in the regex
+		match_dict = match.groupdict()
 
-        # Create the <i> element
-        el = markdown.util.etree.Element("i")
+		# Create the <i> element
+		el = markdown.util.etree.Element("i")
 
-        base = self.config['base']
-        prefix = self.config['prefix']
+		base = self.config['base']
+		prefix = self.config['prefix']
 
-        icon_class_name = match_dict.get("name")
+		icon_class_name = match_dict.get("name")
 
-        # Mods are modifier classes. The syntax in the markdown is:
-        # "&icon-namehere:2x;" and with multiple "&icon-spinner:2x,spin;"
-        mod_classes_string = ""
-        if match_dict.get("mod"):
-            # Make a string with each modifier like: "fa-2x fa-spin"
-            mod_classes_string = ' '.join('{}{}'.format(prefix, c) for c in match_dict.get("mod").split(",") if c)
+		# Mods are modifier classes. The syntax in the markdown is:
+		# "&icon-namehere:2x;" and with multiple "&icon-spinner:2x,spin;"
+		mod_classes_string = ""
+		if match_dict.get("mod"):
+			# Make a string with each modifier like: "fa-2x fa-spin"
+			mod_classes_string = ' '.join('{}{}'.format(prefix, c) for c in match_dict.get("mod").split(",") if c)
 
-        # User mods are modifier classes that shouldn't be prefixed with
-        # prefix. The syntax in the markdown is:
-        # "&icon-namehere::red;" and with multiple "&icon-spinner::red,bold;"
-        user_mod_classes_string = ""
-        if match_dict.get("user_mod"):
-            # Make a string with each modifier like "red bold"
-            user_mod_classes_string = ' '.join(uc for uc in match_dict.get("user_mod").split(",") if uc)
+		# User mods are modifier classes that shouldn't be prefixed with
+		# prefix. The syntax in the markdown is:
+		# "&icon-namehere::red;" and with multiple "&icon-spinner::red,bold;"
+		user_mod_classes_string = ""
+		if match_dict.get("user_mod"):
+			# Make a string with each modifier like "red bold"
+			user_mod_classes_string = ' '.join(uc for uc in match_dict.get("user_mod").split(",") if uc)
 
-        if prefix != '':
-            icon_class = '{}{}'.format(prefix, icon_class_name)
-        else:
-            icon_class = icon_class_name
+		if prefix != '':
+			icon_class = '{}{}'.format(prefix, icon_class_name)
+		else:
+			icon_class = icon_class_name
 
-        # Add the icon classes to the <i> element
-        classes = '{} {} {} {}'.format(base, icon_class, mod_classes_string, user_mod_classes_string)
+		# Add the icon classes to the <i> element
+		classes = '{} {} {} {}'.format(base, icon_class, mod_classes_string, user_mod_classes_string)
 
-        # Clean up classes
-        classes = classes.strip()
-        classes = re.sub(r'\s{2,}', ' ', classes)
+		# Clean up classes
+		classes = classes.strip()
+		classes = re.sub(r'\s{2,}', ' ', classes)
 
-        el.set('class', classes)
-        # This is for accessibility and text-to-speech browsers so they don't try to read it
-        el.set('aria-hidden', 'true')
-        return el
+		el.set('class', classes)
+		# This is for accessibility and text-to-speech browsers so they don't try to read it
+		el.set('aria-hidden', 'true')
+		return el
 
 
 # http://pythonhosted.org/Markdown/extensions/api.html#makeextension
 def makeExtension(*args, **kwargs):
-    return IconFontsExtension(*args, **kwargs)
+	return IconFontsExtension(*args, **kwargs)

--- a/tests/unit-tests.py
+++ b/tests/unit-tests.py
@@ -5,115 +5,117 @@ import markdown
 
 
 class TestMDI(unittest.TestCase):
-    def test_vanilla(self):
-        text = 'I love &icon-html5; and &icon-css3;.'
-        expected = '<p>I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>.</p>'
+	def test_vanilla(self):
+		text = 'I love &icon-html5; and &icon-css3;.'
+		expected = '<p>I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>.</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts'])
-        converted_text = md.convert(text)
+		md = markdown.Markdown(extensions=['iconfonts'])
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
-    def test_vanilla_mod(self):
-        text = 'I also love &icon-spinner:spin; &icon-spinner:2x,spin;\n&icon-spinner:large,spin; Sorry we have to load...'
-        expected = '<p>I also love <i aria-hidden="true" class="icon-spinner icon-spin"></i> <i aria-hidden="true" class="icon-spinner icon-2x icon-spin"></i>\n<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
+	def test_vanilla_mod(self):
+		text = 'I also love &icon-spinner:spin; &icon-spinner:2x,spin;\n&icon-spinner:large,spin; Sorry we have to load...'
+		expected = '<p>I also love <i aria-hidden="true" class="icon-spinner icon-spin"></i> <i aria-hidden="true" class="icon-spinner icon-2x icon-spin"></i>\n<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts'])
-        converted_text = md.convert(text)
+		md = markdown.Markdown(extensions=['iconfonts'])
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
-    def test_vanilla_user_mod(self):
-        text = 'I also love &icon-spinner:spin:red; &icon-spinner:2x,spin:bold;\n&icon-spinner:large,spin; Sorry we have to load...'
-        expected = '<p>I also love <i aria-hidden="true" class="icon-spinner icon-spin red"></i> <i aria-hidden="true" class="icon-spinner icon-2x icon-spin bold"></i>\n<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
+	def test_vanilla_user_mod(self):
+		text = 'I also love &icon-spinner:spin:red; &icon-spinner:2x,spin:bold;\n&icon-spinner:large,spin; Sorry we have to load...'
+		expected = '<p>I also love <i aria-hidden="true" class="icon-spinner icon-spin red"></i> <i aria-hidden="true" class="icon-spinner icon-2x icon-spin bold"></i>\n<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts'])
-        converted_text = md.convert(text)
+		md = markdown.Markdown(extensions=['iconfonts'])
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
-    def test_prefix_base_pairs_setting(self):
-        text = 'I also love &fa-spinner:2x,spin:red; &glyphicon-remove::bold;\n&fa-spinner:large,spin; Sorry we have to load...'
-        expected = '<p>I also love <i aria-hidden="true" class="fa fa-spinner fa-2x fa-spin red"></i> <i aria-hidden="true" class="glyphicon glyphicon-remove bold"></i>\n<i aria-hidden="true" class="fa fa-spinner fa-large fa-spin"></i> Sorry we have to load...</p>'
+	def test_prefix_base_pairs_setting(self):
+		text = 'I also love &fa-spinner:2x,spin:red; &glyphicon-remove::bold;\n&fa-spinner:large,spin; Sorry we have to load...'
+		expected = '<p>I also love <i aria-hidden="true" class="fa fa-spinner fa-2x fa-spin red"></i> <i aria-hidden="true" class="glyphicon glyphicon-remove bold"></i>\n<i aria-hidden="true" class="fa fa-spinner fa-large fa-spin"></i> Sorry we have to load...</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts'],
-                               extension_configs={
-                                   'iconfonts': {
-                                       'prefix': 'icon-',
-                                       'base': 'icon',
-                                       'prefix_base_pairs': {
-                                           'fa-': 'fa',
-                                           'glyphicon-': 'glyphicon',
-                                       }
-                                   }
-                               })
-        converted_text = md.convert(text)
+		md = markdown.Markdown(
+			extensions=['iconfonts'],
+			extension_configs={
+				'iconfonts': {
+					'prefix': 'icon-',
+					'base': 'icon',
+					'prefix_base_pairs': {
+						'fa-': 'fa',
+						'glyphicon-': 'glyphicon',
+					}
+				}
+			})
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
-    def test_prefix_base_pairs_setting_with_normal_prefix_and_base_settings(self):
-        text = 'I also love &fa-spinner:2x,spin:red; &glyphicon-remove::bold;\n&icon-spinner:large,spin; Sorry we have to load...'
-        expected = '<p>I also love <i aria-hidden="true" class="fa fa-spinner fa-2x fa-spin red"></i> <i aria-hidden="true" class="glyphicon glyphicon-remove bold"></i>\n<i aria-hidden="true" class="icon icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
+	def test_prefix_base_pairs_setting_with_normal_prefix_and_base_settings(self):
+		text = 'I also love &fa-spinner:2x,spin:red; &glyphicon-remove::bold;\n&icon-spinner:large,spin; Sorry we have to load...'
+		expected = '<p>I also love <i aria-hidden="true" class="fa fa-spinner fa-2x fa-spin red"></i> <i aria-hidden="true" class="glyphicon glyphicon-remove bold"></i>\n<i aria-hidden="true" class="icon icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts'],
-                               extension_configs={
-                                   'iconfonts': {
-                                       'prefix': 'icon-',
-                                       'base': 'icon',
-                                       'prefix_base_pairs': {
-                                           'fa-': 'fa',
-                                           'glyphicon-': 'glyphicon',
-                                       }
-                                   }
-                               })
-        converted_text = md.convert(text)
+		md = markdown.Markdown(
+			extensions=['iconfonts'],
+			extension_configs={
+				'iconfonts': {
+					'prefix': 'icon-',
+					'base': 'icon',
+					'prefix_base_pairs': {
+						'fa-': 'fa',
+						'glyphicon-': 'glyphicon',
+					}
+				}
+			})
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
-    def test_custom_prefix(self):
-        text = 'I love &mypref-html5; and &mypref-css3;.'
-        expected = '<p>I love <i aria-hidden="true" class="mypref-html5"></i> and <i aria-hidden="true" class="mypref-css3"></i>.</p>'
+	def test_custom_prefix(self):
+		text = 'I love &mypref-html5; and &mypref-css3;.'
+		expected = '<p>I love <i aria-hidden="true" class="mypref-html5"></i> and <i aria-hidden="true" class="mypref-css3"></i>.</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
-        converted_text = md.convert(text)
+		md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
-    def test_custom_prefix_mod(self):
-        text = 'I also love &mypref-spinner:spin; &mypref-spinner:2x,spin;\n&mypref-spinner:large,spin; Sorry we have to load...'
-        expected = '<p>I also love <i aria-hidden="true" class="mypref-spinner mypref-spin"></i> <i aria-hidden="true" class="mypref-spinner mypref-2x mypref-spin"></i>\n<i aria-hidden="true" class="mypref-spinner mypref-large mypref-spin"></i> Sorry we have to load...</p>'
+	def test_custom_prefix_mod(self):
+		text = 'I also love &mypref-spinner:spin; &mypref-spinner:2x,spin;\n&mypref-spinner:large,spin; Sorry we have to load...'
+		expected = '<p>I also love <i aria-hidden="true" class="mypref-spinner mypref-spin"></i> <i aria-hidden="true" class="mypref-spinner mypref-2x mypref-spin"></i>\n<i aria-hidden="true" class="mypref-spinner mypref-large mypref-spin"></i> Sorry we have to load...</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
-        converted_text = md.convert(text)
+		md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
-    def test_base(self):
-        text = 'I love &icon-html5; and &icon-css3;.'
-        expected = '<p>I love <i aria-hidden="true" class="icon icon-html5"></i> and <i aria-hidden="true" class="icon icon-css3"></i>.</p>'
+	def test_base(self):
+		text = 'I love &icon-html5; and &icon-css3;.'
+		expected = '<p>I love <i aria-hidden="true" class="icon icon-html5"></i> and <i aria-hidden="true" class="icon icon-css3"></i>.</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts(base=icon)'])
-        converted_text = md.convert(text)
+		md = markdown.Markdown(extensions=['iconfonts(base=icon)'])
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
-    def test_complex(self):
-        text = 'I love &fa-html5; and &fa-css3;.'
-        expected = '<p>I love <i aria-hidden="true" class="fa fa-html5"></i> and <i aria-hidden="true" class="fa fa-css3"></i>.</p>'
+	def test_complex(self):
+		text = 'I love &fa-html5; and &fa-css3;.'
+		expected = '<p>I love <i aria-hidden="true" class="fa fa-html5"></i> and <i aria-hidden="true" class="fa fa-css3"></i>.</p>'
 
-        md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
-        converted_text = md.convert(text)
+		md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
+		converted_text = md.convert(text)
 
-        self.assertEqual(converted_text, expected)
+		self.assertEqual(converted_text, expected)
 
 
 """
 # Save to file
 BASE_DIR = os.path.realpath(os.path.dirname(__file__))
 with open(os.path.join(BASE_DIR, 'output.txt'), "w") as text_file:
-    text_file.write(str(converted_text))
+	text_file.write(str(converted_text))
 """
 
 
 if __name__ == '__main__':
-    unittest.main()
+	unittest.main()

--- a/tests/unit-tests.py
+++ b/tests/unit-tests.py
@@ -4,59 +4,59 @@ import os
 import markdown
 
 class TestMDI(unittest.TestCase):
-	def test_vanilla(self):
-		text = 'I love &icon-html5; and &icon-css3;.'
-		expected = '<p>I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>.</p>'
+    def test_vanilla(self):
+        text = 'I love &icon-html5; and &icon-css3;.'
+        expected = '<p>I love <i aria-hidden="true" class="icon-html5"></i> and <i aria-hidden="true" class="icon-css3"></i>.</p>'
 
-		md = markdown.Markdown(extensions=['iconfonts'])
-		converted_text = md.convert(text)
+        md = markdown.Markdown(extensions=['iconfonts'])
+        converted_text = md.convert(text)
 
-		self.assertEqual(converted_text, expected)
+        self.assertEqual(converted_text, expected)
 
-	def test_vanilla_mod(self):
-		text = 'I also love &icon-spinner:spin; &icon-spinner:2x,spin;\n&icon-spinner:large,spin; Sorry we have to load...'
-		expected = '<p>I also love <i aria-hidden="true" class="icon-spinner icon-spin"></i> <i aria-hidden="true" class="icon-spinner icon-2x icon-spin"></i>\n<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
+    def test_vanilla_mod(self):
+        text = 'I also love &icon-spinner:spin; &icon-spinner:2x,spin;\n&icon-spinner:large,spin; Sorry we have to load...'
+        expected = '<p>I also love <i aria-hidden="true" class="icon-spinner icon-spin"></i> <i aria-hidden="true" class="icon-spinner icon-2x icon-spin"></i>\n<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
 
-		md = markdown.Markdown(extensions=['iconfonts'])
-		converted_text = md.convert(text)
+        md = markdown.Markdown(extensions=['iconfonts'])
+        converted_text = md.convert(text)
 
-		self.assertEqual(converted_text, expected)
+        self.assertEqual(converted_text, expected)
 
-	def test_custom_prefix(self):
-		text = 'I love &mypref-html5; and &mypref-css3;.'
-		expected = '<p>I love <i aria-hidden="true" class="mypref-html5"></i> and <i aria-hidden="true" class="mypref-css3"></i>.</p>'
+    def test_custom_prefix(self):
+        text = 'I love &mypref-html5; and &mypref-css3;.'
+        expected = '<p>I love <i aria-hidden="true" class="mypref-html5"></i> and <i aria-hidden="true" class="mypref-css3"></i>.</p>'
 
-		md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
-		converted_text = md.convert(text)
+        md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
+        converted_text = md.convert(text)
 
-		self.assertEqual(converted_text, expected)
+        self.assertEqual(converted_text, expected)
 
-	def test_custom_prefix_mod(self):
-		text = 'I also love &mypref-spinner:spin; &mypref-spinner:2x,spin;\n&mypref-spinner:large,spin; Sorry we have to load...'
-		expected = '<p>I also love <i aria-hidden="true" class="mypref-spinner mypref-spin"></i> <i aria-hidden="true" class="mypref-spinner mypref-2x mypref-spin"></i>\n<i aria-hidden="true" class="mypref-spinner mypref-large mypref-spin"></i> Sorry we have to load...</p>'
+    def test_custom_prefix_mod(self):
+        text = 'I also love &mypref-spinner:spin; &mypref-spinner:2x,spin;\n&mypref-spinner:large,spin; Sorry we have to load...'
+        expected = '<p>I also love <i aria-hidden="true" class="mypref-spinner mypref-spin"></i> <i aria-hidden="true" class="mypref-spinner mypref-2x mypref-spin"></i>\n<i aria-hidden="true" class="mypref-spinner mypref-large mypref-spin"></i> Sorry we have to load...</p>'
 
-		md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
-		converted_text = md.convert(text)
+        md = markdown.Markdown(extensions=['iconfonts(prefix=mypref-)'])
+        converted_text = md.convert(text)
 
-		self.assertEqual(converted_text, expected)
+        self.assertEqual(converted_text, expected)
 
-	def test_base(self):
-		text = 'I love &icon-html5; and &icon-css3;.'
-		expected = '<p>I love <i aria-hidden="true" class="icon icon-html5"></i> and <i aria-hidden="true" class="icon icon-css3"></i>.</p>'
+    def test_base(self):
+        text = 'I love &icon-html5; and &icon-css3;.'
+        expected = '<p>I love <i aria-hidden="true" class="icon icon-html5"></i> and <i aria-hidden="true" class="icon icon-css3"></i>.</p>'
 
-		md = markdown.Markdown(extensions=['iconfonts(base=icon)'])
-		converted_text = md.convert(text)
+        md = markdown.Markdown(extensions=['iconfonts(base=icon)'])
+        converted_text = md.convert(text)
 
-		self.assertEqual(converted_text, expected)
+        self.assertEqual(converted_text, expected)
 
-	def test_complex(self):
-		text = 'I love &fa-html5; and &fa-css3;.'
-		expected = '<p>I love <i aria-hidden="true" class="fa fa-html5"></i> and <i aria-hidden="true" class="fa fa-css3"></i>.</p>'
+    def test_complex(self):
+        text = 'I love &fa-html5; and &fa-css3;.'
+        expected = '<p>I love <i aria-hidden="true" class="fa fa-html5"></i> and <i aria-hidden="true" class="fa fa-css3"></i>.</p>'
 
-		md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
-		converted_text = md.convert(text)
+        md = markdown.Markdown(extensions=['iconfonts(prefix=fa-, base=fa)'])
+        converted_text = md.convert(text)
 
-		self.assertEqual(converted_text, expected)
+        self.assertEqual(converted_text, expected)
 
 
 
@@ -65,7 +65,7 @@ class TestMDI(unittest.TestCase):
 # Save to file
 BASE_DIR = os.path.realpath(os.path.dirname(__file__))
 with open(os.path.join(BASE_DIR, 'output.txt'), "w") as text_file:
-	text_file.write(str(converted_text))
+    text_file.write(str(converted_text))
 """
 
 

--- a/tests/unit-tests.py
+++ b/tests/unit-tests.py
@@ -32,6 +32,44 @@ class TestMDI(unittest.TestCase):
 
         self.assertEqual(converted_text, expected)
 
+    def test_prefix_base_pairs_setting(self):
+        text = 'I also love &fa-spinner:2x,spin:red; &glyphicon-remove::bold;\n&fa-spinner:large,spin; Sorry we have to load...'
+        expected = '<p>I also love <i aria-hidden="true" class="fa fa-spinner fa-2x fa-spin red"></i> <i aria-hidden="true" class="glyphicon glyphicon-remove bold"></i>\n<i aria-hidden="true" class="fa fa-spinner fa-large fa-spin"></i> Sorry we have to load...</p>'
+
+        md = markdown.Markdown(extensions=['iconfonts'],
+                               extension_configs={
+                                   'iconfonts': {
+                                       'prefix': 'icon-',
+                                       'base': 'icon',
+                                       'prefix_base_pairs': {
+                                           'fa-': 'fa',
+                                           'glyphicon-': 'glyphicon',
+                                       }
+                                   }
+                               })
+        converted_text = md.convert(text)
+
+        self.assertEqual(converted_text, expected)
+
+    def test_prefix_base_pairs_setting_with_normal_prefix_and_base_settings(self):
+        text = 'I also love &fa-spinner:2x,spin:red; &glyphicon-remove::bold;\n&icon-spinner:large,spin; Sorry we have to load...'
+        expected = '<p>I also love <i aria-hidden="true" class="fa fa-spinner fa-2x fa-spin red"></i> <i aria-hidden="true" class="glyphicon glyphicon-remove bold"></i>\n<i aria-hidden="true" class="icon icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
+
+        md = markdown.Markdown(extensions=['iconfonts'],
+                               extension_configs={
+                                   'iconfonts': {
+                                       'prefix': 'icon-',
+                                       'base': 'icon',
+                                       'prefix_base_pairs': {
+                                           'fa-': 'fa',
+                                           'glyphicon-': 'glyphicon',
+                                       }
+                                   }
+                               })
+        converted_text = md.convert(text)
+
+        self.assertEqual(converted_text, expected)
+
     def test_custom_prefix(self):
         text = 'I love &mypref-html5; and &mypref-css3;.'
         expected = '<p>I love <i aria-hidden="true" class="mypref-html5"></i> and <i aria-hidden="true" class="mypref-css3"></i>.</p>'

--- a/tests/unit-tests.py
+++ b/tests/unit-tests.py
@@ -3,6 +3,7 @@ import unittest
 import os
 import markdown
 
+
 class TestMDI(unittest.TestCase):
     def test_vanilla(self):
         text = 'I love &icon-html5; and &icon-css3;.'
@@ -57,8 +58,6 @@ class TestMDI(unittest.TestCase):
         converted_text = md.convert(text)
 
         self.assertEqual(converted_text, expected)
-
-
 
 
 """

--- a/tests/unit-tests.py
+++ b/tests/unit-tests.py
@@ -23,6 +23,15 @@ class TestMDI(unittest.TestCase):
 
         self.assertEqual(converted_text, expected)
 
+    def test_vanilla_user_mod(self):
+        text = 'I also love &icon-spinner:spin:red; &icon-spinner:2x,spin:bold;\n&icon-spinner:large,spin; Sorry we have to load...'
+        expected = '<p>I also love <i aria-hidden="true" class="icon-spinner icon-spin red"></i> <i aria-hidden="true" class="icon-spinner icon-2x icon-spin bold"></i>\n<i aria-hidden="true" class="icon-spinner icon-large icon-spin"></i> Sorry we have to load...</p>'
+
+        md = markdown.Markdown(extensions=['iconfonts'])
+        converted_text = md.convert(text)
+
+        self.assertEqual(converted_text, expected)
+
     def test_custom_prefix(self):
         text = 'I love &mypref-html5; and &mypref-css3;.'
         expected = '<p>I love <i aria-hidden="true" class="mypref-html5"></i> and <i aria-hidden="true" class="mypref-css3"></i>.</p>'


### PR DESCRIPTION
* ~~Convert indentation to spaces and~~ use Unix line endings
* PEP8 fixups (ignoring line too long errors)
* Extend the syntax to allow classes to pass-through without being prefixed
* Add tests for syntax extension and `prefix_base_pairs` setting

All tests pass.